### PR TITLE
docs: Add npm version and downloads badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # svelte-preprocess-budoux
 
+[![npm version](https://img.shields.io/npm/v/svelte-preprocess-budoux?color=yellow)](https://npmjs.com/package/svelte-preprocess-budoux)
+[![npm downloads](https://img.shields.io/npm/dm/svelte-preprocess-budoux?color=yellow)](https://npmjs.com/package/svelte-preprocess-budoux)
+
 ![Screenshot 2024-07-11 at 11 39 44](https://github.com/ryoppippi/svelte-preprocess-budoux/assets/1560508/03fd68d9-58fc-445b-8186-a42f22114ae2)
 
 ## Configuration


### PR DESCRIPTION
This commit adds two badges to the README file: one for the npm version
and another for the npm downloads. These badges provide quick information
about the package status directly from the README.

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review

- [ ] Did you implement the changes in the correct branch?
- [ ] Is JSDocs for your new implementation up to date?
- [ ] Did you add tests for your changes?
- [ ] Did you update the documentation?
- [ ] Did all CI checks pass?
