### PR TITLE
fix(preprocessor): use this.skip() instead of return

### DIFF
--- a/src/preprocessor.ts
+++ b/src/preprocessor.ts
@@ -28,7 +28,7 @@ function budouxPreprocess(options: Options = {}): PreprocessorGroup {
 
           /* if the node is not an element, we don't care about it */
           if (node.type !== "Element") {
-            return;
+            this.skip()
           }
           const dataAttr = node.attributes.find((attr) =>
             attr.name === attribute
@@ -36,7 +36,7 @@ function budouxPreprocess(options: Options = {}): PreprocessorGroup {
 
           /* if the node does not have the data-budoux attribute, we don't care about it */
           if (dataAttr == null) {
-            return;
+            this.skip()
           }
 
           const { value } = dataAttr as unknown as {


### PR DESCRIPTION
In the budouxPreprocess function, the handling of nodes that are not
elements or do not have the data-budoux attribute has been changed.
Instead of using 'return', 'this.skip()' is now used to skip the
current node and continue with the next one.

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review

- [ ] Did you implement the changes in the correct branch?
- [ ] Is JSDocs for your new implementation up to date?
- [ ] Did you add tests for your changes?
- [ ] Did you update the documentation?
- [ ] Did all CI checks pass?
