### PR TITLE
feat: replace estree-walker with zimmerframe

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
 	"dependencies": {
 		"budoux": "^0.6.2",
 		"defu": "^6.1.4",
-		"estree-walker": "^3.0.3",
 		"magic-string-ast": "^0.6.2",
 		"svelte": "^5.0.0-next.205",
 		"svelte-parse-markup": "^0.1.5"
@@ -50,6 +49,7 @@
 		"mkdist": "^1.5.4",
 		"node-html-parser": "^6.1.13",
 		"typescript": "^5.5.4",
-		"vitest": "^2.0.5"
+		"vitest": "^2.0.5",
+		"zimmerframe": "^1.1.2"
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,9 +14,6 @@ importers:
       defu:
         specifier: ^6.1.4
         version: 6.1.4
-      estree-walker:
-        specifier: ^3.0.3
-        version: 3.0.3
       magic-string-ast:
         specifier: ^0.6.2
         version: 0.6.2
@@ -66,6 +63,9 @@ importers:
       vitest:
         specifier: ^2.0.5
         version: 2.0.5(@types/node@22.1.0)(jsdom@23.2.0)
+      zimmerframe:
+        specifier: ^1.1.2
+        version: 1.1.2
 
   examples/hooks-sveltekit:
     devDependencies:


### PR DESCRIPTION
This commit replaces the estree-walker package with zimmerframe in src/preprocessor.ts. The walk function from zimmerframe is used to traverse the AST. The commit also refactors the budouxPreprocess function to use a state array for storing nodes and their parsed values, which are then used to overwrite the original nodes. This change improves the efficiency of the preprocessor.